### PR TITLE
feat: add support for Ubuntu 26.04 (Resolute Raccoon)

### DIFF
--- a/helper/provisioner/provisioner.go
+++ b/helper/provisioner/provisioner.go
@@ -77,6 +77,8 @@ func (s *Provisioner) provisionForDebian() error {
 		ubuntuVersion = "ubuntu22.04"
 	case "noble":
 		ubuntuVersion = "ubuntu24.04"
+	case "resolute":
+		ubuntuVersion = "ubuntu26.04"
 	}
 
 	switch runtime.GOARCH {


### PR DESCRIPTION
Map UBUNTU_CODENAME=resolute to ubuntu26.04 in provisionForDebian, alongside existing jammy (22.04) and noble (24.04) support.