### PR TITLE
fix(obmondo): surface the API's error_text to the operator

### DIFF
--- a/pkg/obmondo/obmondo.go
+++ b/pkg/obmondo/obmondo.go
@@ -68,28 +68,40 @@ func (c *obmondoClient) VerifyInstallToken(input *InstallScriptInput) error {
 	const scriptFailureLogErrorMessage = "failed to validate install token"
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
-		err := errors.New("invalid token")
-		slog.Error(scriptFailureLogErrorMessage, slog.Any("error", err))
-		return err
+		return decodeAPIError(resp.Body, resp.StatusCode, "invalid token")
 	case http.StatusNotAcceptable:
-		err := errors.New("invalid token or certname")
-		slog.Error(scriptFailureLogErrorMessage, slog.Any("error", err))
-		return err
+		return decodeAPIError(resp.Body, resp.StatusCode, "invalid token or certname")
 	case http.StatusOK:
 		return nil
 	case http.StatusBadRequest:
-		apiResponse := &ObmondoAPIResponse[string]{}
-		if err := json.NewDecoder(resp.Body).Decode(apiResponse); err != nil {
-			slog.Error("failed to decode api response", slog.Any("error", err))
-			return err
-		}
-		prettyfmt.PrettyPrintln(prettyfmt.FontRed(fmt.Sprintf("error: %s, resolution: %s", apiResponse.ErrorText, apiResponse.Resolution)))
-		return errors.New(apiResponse.ErrorText)
+		return decodeAPIError(resp.Body, resp.StatusCode, scriptFailureLogErrorMessage)
 	default:
 		err := errors.New(scriptFailureLogErrorMessage)
 		slog.Error(err.Error(), slog.Int("http_status", resp.StatusCode))
 		return err
 	}
+}
+
+// decodeAPIError parses the Obmondo API's response envelope out of body and
+// renders its error_text/resolution to the operator, returning an error
+// built from error_text. Falls back to fallbackMsg (logged with statusCode
+// and the raw body) when body is empty or does not decode into a usable
+// error_text.
+func decodeAPIError(body io.Reader, statusCode int, fallbackMsg string) error {
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		slog.Error(fallbackMsg, slog.Int("http_status", statusCode), slog.Any("error", err))
+		return errors.New(fallbackMsg)
+	}
+
+	apiResponse := &ObmondoAPIResponse[string]{}
+	if err := json.Unmarshal(raw, apiResponse); err != nil || apiResponse.ErrorText == "" {
+		slog.Error(fallbackMsg, slog.Int("http_status", statusCode), slog.String("response", string(raw)))
+		return errors.New(fallbackMsg)
+	}
+
+	prettyfmt.PrettyPrintln(prettyfmt.FontRed(fmt.Sprintf("error: %s, resolution: %s", apiResponse.ErrorText, apiResponse.Resolution)))
+	return errors.New(apiResponse.ErrorText)
 }
 
 func (c *obmondoClient) UpdatePuppetLastRunReport() error {
@@ -114,19 +126,7 @@ func (c *obmondoClient) UpdatePuppetLastRunReport() error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		const failureLogMsg = "api returned non-204 response"
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			slog.Error(fmt.Sprintf("%s, failed to parse JSON body", failureLogMsg),
-				slog.Int("status_code", resp.StatusCode),
-				slog.Any("error", err),
-			)
-
-			return err
-		}
-		err = errors.New("failed to inform about latest puppet run status")
-		slog.Error(fmt.Sprintf("%s while informing about last puppet run status", failureLogMsg), slog.Int("status_code", resp.StatusCode), slog.String("api_response", string(body)))
-		return err
+		return decodeAPIError(resp.Body, resp.StatusCode, "failed to inform about latest puppet run status")
 	}
 
 	return nil
@@ -209,17 +209,12 @@ func (c *obmondoClient) NotifyInstallScriptFailure(input *InstallScriptInput) er
 		}
 	}()
 
-	const scriptFailureLogErrorMessage = "failed to notify about script failure to obmondo"
 	switch resp.StatusCode {
 	case http.StatusUnauthorized:
-		err := errors.New("invalid token")
-		slog.Error(scriptFailureLogErrorMessage, slog.Any("error", err))
-		return err
+		return decodeAPIError(resp.Body, resp.StatusCode, "invalid token")
 
 	case http.StatusNotAcceptable:
-		err := errors.New("invalid token or certname")
-		slog.Error(scriptFailureLogErrorMessage, slog.Any("error", err))
-		return err
+		return decodeAPIError(resp.Body, resp.StatusCode, "invalid token or certname")
 
 	case http.StatusNoContent:
 		fmt.Printf("\nInstallation setup failed, please contact ops@obmondo.com\nDon't worry, obmondo has the failed logs to analyze it.\n") //nolint:revive,forbidigo
@@ -227,11 +222,8 @@ func (c *obmondoClient) NotifyInstallScriptFailure(input *InstallScriptInput) er
 	case http.StatusOK:
 		return nil
 	default:
-		err := errors.New(scriptFailureLogErrorMessage)
-		slog.Error(err.Error(), slog.Int("http_status", resp.StatusCode))
-		return err
+		return decodeAPIError(resp.Body, resp.StatusCode, "failed to notify about script failure to obmondo")
 	}
-
 }
 
 func (c *obmondoClient) getCustomHTTPTransportWithPuppetCerts() (*http.Transport, error) {
@@ -315,8 +307,7 @@ func (c *obmondoClient) GetServiceWindowStatus() (*ServiceWindow, error) {
 	}
 
 	if statusCode != http.StatusOK {
-		slog.Error("unexpected", slog.Int("status_code", statusCode), slog.String("response", string(responseBody)))
-		return nil, fmt.Errorf("unexpected non-200 HTTP status code received: %d", statusCode)
+		return nil, decodeAPIError(bytes.NewReader(responseBody), statusCode, fmt.Sprintf("unexpected non-200 HTTP status code received: %d", statusCode))
 	}
 
 	serviceWindow, err := GetServiceWindowDetails(responseBody)
@@ -353,15 +344,7 @@ func (c *obmondoClient) CloseServiceWindow(windowType, certname, timezone, comme
 	case http.StatusAccepted, http.StatusNoContent, http.StatusAlreadyReported:
 		return nil
 	default:
-		bodyBytes, err := io.ReadAll(closeWindow.Body)
-		if err != nil {
-			slog.Error("failed to read response body", slog.String("error", err.Error()))
-			return err
-		}
-
-		// Log the response status code and body
-		slog.Error("closing service window failed", slog.Int("status_code", closeWindow.StatusCode), slog.String("response", string(bodyBytes)))
-		return fmt.Errorf("incorrect response code received from API: %d", closeWindow.StatusCode)
+		return decodeAPIError(closeWindow.Body, closeWindow.StatusCode, fmt.Sprintf("incorrect response code received from API: %d", closeWindow.StatusCode))
 	}
 }
 
@@ -384,7 +367,7 @@ func (c *obmondoClient) GetCustomerSettings(customerID string) (*CustomerSetting
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code fetching customer settings: %d", resp.StatusCode)
+		return nil, decodeAPIError(resp.Body, resp.StatusCode, fmt.Sprintf("unexpected status code fetching customer settings: %d", resp.StatusCode))
 	}
 
 	var apiResp ObmondoAPIResponse[CustomerSettings]

--- a/pkg/obmondo/obmondo_test.go
+++ b/pkg/obmondo/obmondo_test.go
@@ -1,0 +1,121 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDecodeAPIError(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		statusCode  int
+		fallbackMsg string
+		wantErr     string
+	}{
+		{
+			name:        "renders error_text and resolution from envelope",
+			body:        `{"status":401,"success":false,"data":"","message":"","resolution":"request a new token","error_text":"invalid or expired token"}`,
+			statusCode:  http.StatusUnauthorized,
+			fallbackMsg: "invalid token",
+			wantErr:     "invalid or expired token",
+		},
+		{
+			name:        "falls back when body is empty",
+			body:        "",
+			statusCode:  http.StatusInternalServerError,
+			fallbackMsg: "failed to notify about script failure to obmondo",
+			wantErr:     "failed to notify about script failure to obmondo",
+		},
+		{
+			name:        "falls back when body is malformed JSON",
+			body:        "not json",
+			statusCode:  http.StatusBadGateway,
+			fallbackMsg: "failed to notify about script failure to obmondo",
+			wantErr:     "failed to notify about script failure to obmondo",
+		},
+		{
+			name:        "falls back when envelope decodes but error_text is empty",
+			body:        `{"status":500,"success":false,"data":"","message":"","resolution":"","error_text":""}`,
+			statusCode:  http.StatusInternalServerError,
+			fallbackMsg: "failed to inform about latest puppet run status",
+			wantErr:     "failed to inform about latest puppet run status",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := decodeAPIError(strings.NewReader(tt.body), tt.statusCode, tt.fallbackMsg)
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+			if err.Error() != tt.wantErr {
+				t.Errorf("decodeAPIError() error = %q, want %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) {
+	return 0, errors.New("boom")
+}
+
+func TestDecodeAPIError_BodyReadFailure(t *testing.T) {
+	const fallbackMsg = "failed to inform about latest puppet run status"
+
+	err := decodeAPIError(errReader{}, http.StatusInternalServerError, fallbackMsg)
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if err.Error() != fallbackMsg {
+		t.Errorf("decodeAPIError() error = %q, want %q", err.Error(), fallbackMsg)
+	}
+}
+
+// TestNotifyInstallScriptFailure_RendersAPIError checks that a status-handling
+// method wired to decodeAPIError (here, the 401 branch) surfaces the API's
+// own error_text instead of the hardcoded fallback.
+func TestNotifyInstallScriptFailure_RendersAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"status":401,"success":false,"data":"","message":"","resolution":"request a new install link","error_text":"install token has expired"}`))
+	}))
+	defer server.Close()
+
+	client := &obmondoClient{apiURL: server.URL, notifyInstallScriptFailure: true}
+
+	err := client.NotifyInstallScriptFailure(&InstallScriptInput{Certname: "test.example", Token: "expired-token"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if err.Error() != "install token has expired" {
+		t.Errorf("NotifyInstallScriptFailure() error = %q, want %q", err.Error(), "install token has expired")
+	}
+}
+
+// TestVerifyInstallToken_RendersAPIError checks that VerifyInstallToken's
+// 406 branch surfaces the API's own error_text instead of the hardcoded
+// "invalid token or certname" fallback. This is the path expiry takes,
+// which matters once install-token TTLs shrink and expiry stops being rare.
+func TestVerifyInstallToken_RendersAPIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotAcceptable)
+		_, _ = w.Write([]byte(`{"status":406,"success":false,"data":"","message":"","resolution":"please ensure that certname is registered with us and token has not expired","error_text":"token is expired or certname is not registered"}`))
+	}))
+	defer server.Close()
+
+	client := &obmondoClient{apiURL: server.URL}
+
+	err := client.VerifyInstallToken(&InstallScriptInput{Certname: "test.example", Token: "expired-token"})
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	if err.Error() != "token is expired or certname is not registered" {
+		t.Errorf("VerifyInstallToken() error = %q, want %q", err.Error(), "token is expired or certname is not registered")
+	}
+}


### PR DESCRIPTION
Lifts the envelope-decoding that already existed in `VerifyInstallToken`'s 400 branch into a `decodeAPIError` helper, and applies it to the paths that were still returning hardcoded strings or a bare status code — `VerifyInstallToken` (401/406), `NotifyInstallScriptFailure` (401/406), `UpdatePuppetLastRunReport`, `GetServiceWindowStatus`, `CloseServiceWindow`, `GetCustomerSettings`. Those read the response body already, but only logged it.

So an expired install token reports what the API actually said — `"token is expired or certname is not registered"` — instead of `"invalid token or certname"` or `unexpected non-200 HTTP status code received: 406`. Worth doing now because the API's install-token TTL is dropping from 24h to 1h, which makes expiry routine.

Message-only change: same conditions still fail, same status handling, original strings kept as fallbacks when the body is empty or won't decode. Independent of the API change.

Tests cover the helper (envelope decoded, empty body, unreadable body, read failure) plus `NotifyInstallScriptFailure` and `VerifyInstallToken` end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)