### PR TITLE
feat(run-openvox): let the agent decide the puppet environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ These flags are available for both `linuxaid-install` and `linuxaid-cli`:
 
 ## `linuxaid-install` Specific Flags
 
-- `--environment` / `-E` / `ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`)
+- `--environment` / `-E` / `OPENVOX_ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`)
 
 ## `linuxaid-cli` Command-Specific Flags
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ These flags are available for both `linuxaid-install` and `linuxaid-cli`:
 
 ## `linuxaid-install` Specific Flags
 
-- `--environment` / `-E` / `OPENVOX_ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`)
+- `--environment` / `-E` / `ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`)
 
 ## `linuxaid-cli` Command-Specific Flags
 

--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Initial system provisioning tool that installs and configures the Puppet agent (
 
 ```bash
 # Obmondo customers
-TOKEN='your-token' linuxaid-install --certname web01.example --puppet-server your.openvoxserver.com --openvox-environment master
+TOKEN='your-token' linuxaid-install --certname web01.example --puppet-server your.openvoxserver.com --environment master
 
 # Opensource users (no token required)
-linuxaid-install --certname web01.example --puppet-server your.openvoxserver.com --openvox-environment master
+linuxaid-install --certname web01.example --puppet-server your.openvoxserver.com --environment master
 ```
 
 ### linuxaid-cli
@@ -91,7 +91,7 @@ These flags are available for both `linuxaid-install` and `linuxaid-cli`:
 
 ## `linuxaid-install` Specific Flags
 
-- `--openvox-environment` / `OPENVOX_ENVIRONMENT` - Openvox environment (Linuxaid release version)
+- `--environment` / `-E` / `OPENVOX_ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`). `--openvox-environment` is still accepted as a deprecated alias
 
 ## `linuxaid-cli` Command-Specific Flags
 
@@ -103,7 +103,9 @@ These flags are available for both `linuxaid-install` and `linuxaid-cli`:
 
 ### run-openvox
 
-No command-specific flags available. Uses global flags only.
+- `--environment` / `-E` - Openvox environment for this run only. Without it, the environment set for
+  the server in Obmondo is used, falling back to `master` when the API cannot be reached. The value
+  is never sent to Obmondo, so it applies to that single run
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ These flags are available for both `linuxaid-install` and `linuxaid-cli`:
 
 ## `linuxaid-install` Specific Flags
 
-- `--environment` / `-E` / `OPENVOX_ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`). `--openvox-environment` is still accepted as a deprecated alias
+- `--environment` / `-E` / `OPENVOX_ENVIRONMENT` - Openvox environment to install (Linuxaid release version, default `master`)
 
 ## `linuxaid-cli` Command-Specific Flags
 

--- a/cmd/linuxaid-cli/run-openvox.go
+++ b/cmd/linuxaid-cli/run-openvox.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/config"
+	"gitea.obmondo.com/EnableIT/linuxaid-cli/constant"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/helper"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/checkconnectivity"
 	api "gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/obmondo"
@@ -11,18 +12,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var openvoxEnvFlag string
+
 var runOpenvoxCmd = &cobra.Command{
 	Use:     "run-openvox",
 	Short:   "Execute run-openvox command",
 	Long:    "A longer description of run-openvox command",
-	Example: `$ linuxaid-cli run-openvox --certname web01.example`,
+	Example: `$ linuxaid-cli run-openvox --certname web01.example --openvox-environment testing`,
 	Run: func(*cobra.Command, []string) {
 		RunOpenvox()
 	},
 }
 
 // Run the puppet agent in noop mode for now
-func runOpenvoxAgent() error {
+func runOpenvoxAgent(environment string) error {
 	// Puppet run execution returns total 5 status codes
 	//
 	// 0: The run succeeded with no changes or failures; the system was already in the desired state.
@@ -40,6 +43,11 @@ func runOpenvoxAgent() error {
 	statusCodeSucceededWithChanges := 2
 
 	agentCmd := "/opt/puppetlabs/bin/puppet agent -t --noop"
+	// The agent decides the environment: the ENC no longer sends one, and puppet.conf no longer
+	// pins one, so an environment missing here would leave the run on puppet's own default.
+	if environment != "" {
+		agentCmd += " --environment " + environment
+	}
 	// An explicit --puppet-server/PUPPET_SERVER override must reach the agent
 	// too, otherwise it keeps using the server from puppet.conf.
 	if server := config.GetOpenvoxServer(); server != "" {
@@ -103,8 +111,11 @@ func RunOpenvox() {
 		obmondoAPI.ServerPing()
 	}
 
+	environment := resolveOpenvoxEnvironment(obmondoAPI, certname, opensource)
+	slog.Info("resolved puppet environment", slog.String("environment", environment))
+
 	// Need to have case here later in future, when we migrate the endpoints in go-api
-	if err := runOpenvoxAgent(); err != nil {
+	if err := runOpenvoxAgent(environment); err != nil {
 		slog.Error("unable to run the puppet agent", slog.String("error", err.Error()))
 	}
 
@@ -114,6 +125,48 @@ func RunOpenvox() {
 	}
 }
 
+// resolveOpenvoxEnvironment decides which puppet environment this run uses:
+//
+//  1. --openvox-environment (or OPENVOX_ENVIRONMENT), for a one-off run against another branch or
+//     tag. It is never sent to the API, so it applies to this run only.
+//  2. the environment the API resolved for this certname: the pinned override, or the latest
+//     linuxaid release.
+//  3. the default environment, when the flag is unset and the API cannot be reached.
+func resolveOpenvoxEnvironment(obmondoAPI api.ObmondoClient, certname string, opensource bool) string {
+	if environment := config.GetOpenvoxEnv(); environment != "" {
+		slog.Info("using the environment given on the command line", slog.String("environment", environment))
+		return environment
+	}
+
+	if opensource {
+		return constant.DefaultOpenvoxEnv
+	}
+
+	environment, err := obmondoAPI.GetServerEnvironment(certname)
+	if err != nil {
+		slog.Warn("could not fetch the environment from Obmondo, falling back to the default",
+			slog.Any("error", err), slog.String("environment", constant.DefaultOpenvoxEnv))
+		return constant.DefaultOpenvoxEnv
+	}
+
+	if environment == "" {
+		slog.Warn("Obmondo returned no environment, falling back to the default",
+			slog.String("environment", constant.DefaultOpenvoxEnv))
+		return constant.DefaultOpenvoxEnv
+	}
+
+	return environment
+}
+
 func init() {
 	rootCmd.AddCommand(runOpenvoxCmd)
+
+	// no default here: an unset flag means "ask the API", which is what a normal run does
+	runOpenvoxCmd.Flags().StringVar(&openvoxEnvFlag, constant.CobraFlagOpenvoxEnv, "", "Puppet environment for this run only (defaults to the environment set in Obmondo)")
+
+	v := config.GetViperInstance()
+	// nolint:errcheck
+	v.BindPFlag(constant.CobraFlagOpenvoxEnv, runOpenvoxCmd.Flags().Lookup(constant.CobraFlagOpenvoxEnv))
+	// nolint:errcheck
+	v.BindEnv(constant.CobraFlagOpenvoxEnv, "OPENVOX_ENVIRONMENT")
 }

--- a/cmd/linuxaid-cli/run-openvox.go
+++ b/cmd/linuxaid-cli/run-openvox.go
@@ -111,7 +111,7 @@ func RunOpenvox() {
 		obmondoAPI.ServerPing()
 	}
 
-	environment := resolveOpenvoxEnvironment(obmondoAPI, certname, opensource)
+	environment := resolveOpenvoxEnvironment(obmondoAPI, certname, openvoxEnvFlag, opensource)
 	slog.Info("resolved puppet environment", slog.String("environment", environment))
 
 	// Need to have case here later in future, when we migrate the endpoints in go-api
@@ -128,14 +128,16 @@ func RunOpenvox() {
 // resolveOpenvoxEnvironment decides which puppet environment this run uses:
 //
 //  1. --environment/-E, for a one-off run against another branch or tag. It is never sent to the
-//     API, so it applies to this run only.
+//     API, so it applies to this run only. The flag is read straight from cobra rather than
+//     through viper, whose AutomaticEnv would otherwise let a stray ENVIRONMENT variable pin
+//     every run.
 //  2. the environment the API resolved for this certname: the pinned override, or the latest
 //     linuxaid release.
 //  3. the default environment, when the flag is unset and the API cannot be reached.
-func resolveOpenvoxEnvironment(obmondoAPI api.ObmondoClient, certname string, opensource bool) string {
-	if environment := config.GetEnvironment(); environment != "" {
-		slog.Info("using the environment given on the command line", slog.String("environment", environment))
-		return environment
+func resolveOpenvoxEnvironment(obmondoAPI api.ObmondoClient, certname, flagEnvironment string, opensource bool) string {
+	if flagEnvironment != "" {
+		slog.Info("using the environment given on the command line", slog.String("environment", flagEnvironment))
+		return flagEnvironment
 	}
 
 	if opensource {
@@ -163,11 +165,4 @@ func init() {
 
 	// no default here: an unset flag means "ask the API", which is what a normal run does
 	runOpenvoxCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, "", "Puppet environment for this run only (defaults to the environment set in Obmondo)")
-
-	v := config.GetViperInstance()
-	// no BindEnv here on purpose: linuxaid-install binds OPENVOX_ENVIRONMENT to the release a node
-	// is bootstrapped with, and picking that up here would turn it into a permanent override of
-	// the environment set in Obmondo for every run
-	// nolint:errcheck
-	v.BindPFlag(constant.CobraFlagEnvironment, runOpenvoxCmd.Flags().Lookup(constant.CobraFlagEnvironment))
 }

--- a/cmd/linuxaid-cli/run-openvox.go
+++ b/cmd/linuxaid-cli/run-openvox.go
@@ -127,8 +127,8 @@ func RunOpenvox() {
 
 // resolveOpenvoxEnvironment decides which puppet environment this run uses:
 //
-//  1. --environment/-E (or OPENVOX_ENVIRONMENT), for a one-off run against another branch or tag.
-//     It is never sent to the API, so it applies to this run only.
+//  1. --environment/-E, for a one-off run against another branch or tag. It is never sent to the
+//     API, so it applies to this run only.
 //  2. the environment the API resolved for this certname: the pinned override, or the latest
 //     linuxaid release.
 //  3. the default environment, when the flag is unset and the API cannot be reached.
@@ -165,8 +165,9 @@ func init() {
 	runOpenvoxCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, "", "Puppet environment for this run only (defaults to the environment set in Obmondo)")
 
 	v := config.GetViperInstance()
+	// no BindEnv here on purpose: linuxaid-install binds OPENVOX_ENVIRONMENT to the release a node
+	// is bootstrapped with, and picking that up here would turn it into a permanent override of
+	// the environment set in Obmondo for every run
 	// nolint:errcheck
 	v.BindPFlag(constant.CobraFlagEnvironment, runOpenvoxCmd.Flags().Lookup(constant.CobraFlagEnvironment))
-	// nolint:errcheck
-	v.BindEnv(constant.CobraFlagEnvironment, "OPENVOX_ENVIRONMENT")
 }

--- a/cmd/linuxaid-cli/run-openvox.go
+++ b/cmd/linuxaid-cli/run-openvox.go
@@ -18,7 +18,7 @@ var runOpenvoxCmd = &cobra.Command{
 	Use:     "run-openvox",
 	Short:   "Execute run-openvox command",
 	Long:    "A longer description of run-openvox command",
-	Example: `$ linuxaid-cli run-openvox --certname web01.example --openvox-environment testing`,
+	Example: `$ linuxaid-cli run-openvox --certname web01.example --environment testing`,
 	Run: func(*cobra.Command, []string) {
 		RunOpenvox()
 	},
@@ -127,13 +127,13 @@ func RunOpenvox() {
 
 // resolveOpenvoxEnvironment decides which puppet environment this run uses:
 //
-//  1. --openvox-environment (or OPENVOX_ENVIRONMENT), for a one-off run against another branch or
-//     tag. It is never sent to the API, so it applies to this run only.
+//  1. --environment/-E (or OPENVOX_ENVIRONMENT), for a one-off run against another branch or tag.
+//     It is never sent to the API, so it applies to this run only.
 //  2. the environment the API resolved for this certname: the pinned override, or the latest
 //     linuxaid release.
 //  3. the default environment, when the flag is unset and the API cannot be reached.
 func resolveOpenvoxEnvironment(obmondoAPI api.ObmondoClient, certname string, opensource bool) string {
-	if environment := config.GetOpenvoxEnv(); environment != "" {
+	if environment := config.GetEnvironment(); environment != "" {
 		slog.Info("using the environment given on the command line", slog.String("environment", environment))
 		return environment
 	}
@@ -162,11 +162,11 @@ func init() {
 	rootCmd.AddCommand(runOpenvoxCmd)
 
 	// no default here: an unset flag means "ask the API", which is what a normal run does
-	runOpenvoxCmd.Flags().StringVar(&openvoxEnvFlag, constant.CobraFlagOpenvoxEnv, "", "Puppet environment for this run only (defaults to the environment set in Obmondo)")
+	runOpenvoxCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, "", "Puppet environment for this run only (defaults to the environment set in Obmondo)")
 
 	v := config.GetViperInstance()
 	// nolint:errcheck
-	v.BindPFlag(constant.CobraFlagOpenvoxEnv, runOpenvoxCmd.Flags().Lookup(constant.CobraFlagOpenvoxEnv))
+	v.BindPFlag(constant.CobraFlagEnvironment, runOpenvoxCmd.Flags().Lookup(constant.CobraFlagEnvironment))
 	// nolint:errcheck
-	v.BindEnv(constant.CobraFlagOpenvoxEnv, "OPENVOX_ENVIRONMENT")
+	v.BindEnv(constant.CobraFlagEnvironment, "OPENVOX_ENVIRONMENT")
 }

--- a/cmd/linuxaid-cli/run-openvox_test.go
+++ b/cmd/linuxaid-cli/run-openvox_test.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"gitea.obmondo.com/EnableIT/linuxaid-cli/config"
+	"gitea.obmondo.com/EnableIT/linuxaid-cli/constant"
+	"gitea.obmondo.com/EnableIT/linuxaid-cli/mock"
+	api "gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/obmondo"
+)
+
+// failingEnvironmentClient stands in for an unreachable Obmondo API.
+type failingEnvironmentClient struct {
+	api.ObmondoClient
+}
+
+func (*failingEnvironmentClient) GetServerEnvironment(_ string) (string, error) {
+	return "", errors.New("api is unreachable")
+}
+
+// emptyEnvironmentClient answers without resolving an environment.
+type emptyEnvironmentClient struct {
+	api.ObmondoClient
+}
+
+func (*emptyEnvironmentClient) GetServerEnvironment(_ string) (string, error) {
+	return "", nil
+}
+
+func TestResolveOpenvoxEnvironment(t *testing.T) {
+	const certname = "hostname.example"
+
+	tests := []struct {
+		name       string
+		flagValue  string
+		client     api.ObmondoClient
+		opensource bool
+		expected   string
+	}{
+		{
+			name:      "the flag wins over the environment set in Obmondo",
+			flagValue: "testing",
+			client:    mock.NewMockObmondoClient(),
+			expected:  "testing",
+		},
+		{
+			name:     "without the flag the environment comes from Obmondo",
+			client:   mock.NewMockObmondoClient(),
+			expected: mock.MockServerEnvironment,
+		},
+		{
+			name:     "an unreachable api falls back to the default environment",
+			client:   &failingEnvironmentClient{},
+			expected: constant.DefaultOpenvoxEnv,
+		},
+		{
+			name:     "an unresolved environment falls back to the default environment",
+			client:   &emptyEnvironmentClient{},
+			expected: constant.DefaultOpenvoxEnv,
+		},
+		{
+			// opensource nodes are not registered with Obmondo, so they never call the API
+			name:       "opensource nodes use the default environment",
+			client:     &failingEnvironmentClient{},
+			opensource: true,
+			expected:   constant.DefaultOpenvoxEnv,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config.GetViperInstance().Set(constant.CobraFlagOpenvoxEnv, test.flagValue)
+			t.Cleanup(func() {
+				config.GetViperInstance().Set(constant.CobraFlagOpenvoxEnv, "")
+			})
+
+			environment := resolveOpenvoxEnvironment(test.client, certname, test.opensource)
+			if environment != test.expected {
+				t.Errorf("expected environment %q, got %q", test.expected, environment)
+			}
+		})
+	}
+}

--- a/cmd/linuxaid-cli/run-openvox_test.go
+++ b/cmd/linuxaid-cli/run-openvox_test.go
@@ -70,9 +70,9 @@ func TestResolveOpenvoxEnvironment(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			config.GetViperInstance().Set(constant.CobraFlagOpenvoxEnv, test.flagValue)
+			config.GetViperInstance().Set(constant.CobraFlagEnvironment, test.flagValue)
 			t.Cleanup(func() {
-				config.GetViperInstance().Set(constant.CobraFlagOpenvoxEnv, "")
+				config.GetViperInstance().Set(constant.CobraFlagEnvironment, "")
 			})
 
 			environment := resolveOpenvoxEnvironment(test.client, certname, test.opensource)

--- a/cmd/linuxaid-cli/run-openvox_test.go
+++ b/cmd/linuxaid-cli/run-openvox_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"gitea.obmondo.com/EnableIT/linuxaid-cli/config"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/constant"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/mock"
 	api "gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/obmondo"
@@ -70,12 +69,7 @@ func TestResolveOpenvoxEnvironment(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			config.GetViperInstance().Set(constant.CobraFlagEnvironment, test.flagValue)
-			t.Cleanup(func() {
-				config.GetViperInstance().Set(constant.CobraFlagEnvironment, "")
-			})
-
-			environment := resolveOpenvoxEnvironment(test.client, certname, test.opensource)
+			environment := resolveOpenvoxEnvironment(test.client, certname, test.flagValue, test.opensource)
 			if environment != test.expected {
 				t.Errorf("expected environment %q, got %q", test.expected, environment)
 			}

--- a/cmd/linuxaid-cli/system-update.go
+++ b/cmd/linuxaid-cli/system-update.go
@@ -152,8 +152,8 @@ func updateRedHat() error {
 // ------------------------------------------------
 
 // HandlePuppetRun is resposible to run the puppet-agent and handle the status codes of the execution
-func HandlePuppetRun(puppetService *puppet.Service) error {
-	exitCode := puppetService.RunAgent(false, "noop")
+func HandlePuppetRun(puppetService *puppet.Service, environment string) error {
+	exitCode := puppetService.RunAgent(false, "noop", environment)
 	if slices.Contains(constant.PuppetSuccessExitCodes, exitCode) {
 		slog.Info("everything is fine with puppet agent run, let's continue.")
 		return nil
@@ -388,8 +388,11 @@ func SystemUpdate() {
 		// Check if any existing puppet agent is already running
 		puppetService.WaitForAgent(constant.PuppetWaitForCertTimeOut)
 
+		// puppet.conf no longer pins an environment, so the run needs the one set in Obmondo
+		environment := resolveOpenvoxEnvironment(obmondoAPI, certname, "", helper.IsOpensourceMode())
+
 		// Run puppet-agent and check the exit code, and exit this script, if it's not 0 or 2
-		if err := HandlePuppetRun(puppetService); err != nil {
+		if err := HandlePuppetRun(puppetService, environment); err != nil {
 			slog.Error("unable to run puppet-agent", slog.String("error", err.Error()))
 			return
 		}

--- a/cmd/linuxaid-install/install.go
+++ b/cmd/linuxaid-install/install.go
@@ -95,7 +95,7 @@ func Install() {
 
 	certname := helper.GetCertname()
 	openvoxServer := config.GetOpenvoxServer()
-	openvoxEnv := config.GetInstallEnvironment()
+	openvoxEnv := installEnvironment()
 	obmondoAPIURL := api.GetObmondoURL()
 	obmondoAPI := api.NewObmondoClient(obmondoAPIURL, true)
 	webtee := webtee.NewWebtee(obmondoAPI)

--- a/cmd/linuxaid-install/install.go
+++ b/cmd/linuxaid-install/install.go
@@ -95,7 +95,7 @@ func Install() {
 
 	certname := helper.GetCertname()
 	openvoxServer := config.GetOpenvoxServer()
-	openvoxEnv := config.GetOpenvoxEnv()
+	openvoxEnv := config.GetInstallEnvironment()
 	obmondoAPIURL := api.GetObmondoURL()
 	obmondoAPI := api.NewObmondoClient(obmondoAPIURL, true)
 	webtee := webtee.NewWebtee(obmondoAPI)

--- a/cmd/linuxaid-install/install.go
+++ b/cmd/linuxaid-install/install.go
@@ -162,7 +162,7 @@ func Install() {
 	// nolint: errcheck
 	progress.NonDeterministicFunc("Running Openvox", func() error {
 		puppetService.WaitForAgent(constant.PuppetWaitForCertTimeOut)
-		puppetService.RunAgent(true, "noop")
+		puppetService.RunAgent(true, "noop", openvoxEnv)
 		if hasToken {
 			// nolint:errcheck
 			obmondoAPI.UpdatePuppetLastRunReport()

--- a/cmd/linuxaid-install/main.go
+++ b/cmd/linuxaid-install/main.go
@@ -98,7 +98,7 @@ func init() {
 }
 
 // installEnvironment is the openvox environment the node is bootstrapped with: the --environment
-// flag, then the ENVIRONMENT variable, then the default release. It is read here rather than
+// flag, then the OPENVOX_ENVIRONMENT variable, then the default release. It is read here rather than
 // through viper so the environment variable is an explicit choice instead of whatever
 // viper.AutomaticEnv happens to match.
 func installEnvironment() string {
@@ -106,7 +106,7 @@ func installEnvironment() string {
 		return openvoxEnvFlag
 	}
 
-	if environment := os.Getenv(constant.EnvVarEnvironment); environment != "" {
+	if environment := os.Getenv(constant.EnvVarOpenvoxEnvironment); environment != "" {
 		return environment
 	}
 

--- a/cmd/linuxaid-install/main.go
+++ b/cmd/linuxaid-install/main.go
@@ -79,24 +79,38 @@ func init() {
 	rootCmd.Flags().BoolVar(&debugFlag, "debug", false, "Enable debug logs")
 	rootCmd.Flags().StringVar(&certNameFlag, constant.CobraFlagCertname, "", "Certificate name (defaults to the machine's FQDN)")
 	rootCmd.Flags().StringVar(&openvoxServerFlag, constant.CobraFlagOpenvoxServer, defaultServer, "Puppet server hostname")
-	rootCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, constant.DefaultOpenvoxEnv, "Openvox environment to install (Linuxaid release version)")
+	// no default here: it is applied in installEnvironment(), after the environment variable
+	rootCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, "", "Openvox environment to install (Linuxaid release version, default "+constant.DefaultOpenvoxEnv+")")
 
 	// Bind flags to viper
 	v := config.GetViperInstance()
 	v.BindPFlag(constant.CobraFlagDebug, rootCmd.Flags().Lookup(constant.CobraFlagDebug))
 	v.BindPFlag(constant.CobraFlagCertname, rootCmd.Flags().Lookup(constant.CobraFlagCertname))
 	v.BindPFlag(constant.CobraFlagOpenvoxServer, rootCmd.Flags().Lookup(constant.CobraFlagOpenvoxServer))
-	v.BindPFlag(constant.ViperKeyInstallEnvironment, rootCmd.Flags().Lookup(constant.CobraFlagEnvironment))
 
 	// Bind environment variables
 	v.BindEnv(constant.CobraFlagDebug)
 	v.BindEnv(constant.CobraFlagCertname)
 	v.BindEnv(constant.CobraFlagOpenvoxServer, "PUPPET_SERVER")
-	v.BindEnv(constant.ViperKeyInstallEnvironment, "OPENVOX_ENVIRONMENT")
 
 	// Set default values
 	v.SetDefault(constant.CobraFlagOpenvoxServer, defaultServer)
-	v.SetDefault(constant.ViperKeyInstallEnvironment, constant.DefaultOpenvoxEnv)
+}
+
+// installEnvironment is the openvox environment the node is bootstrapped with: the --environment
+// flag, then the ENVIRONMENT variable, then the default release. It is read here rather than
+// through viper so the environment variable is an explicit choice instead of whatever
+// viper.AutomaticEnv happens to match.
+func installEnvironment() string {
+	if openvoxEnvFlag != "" {
+		return openvoxEnvFlag
+	}
+
+	if environment := os.Getenv(constant.EnvVarEnvironment); environment != "" {
+		return environment
+	}
+
+	return constant.DefaultOpenvoxEnv
 }
 
 func main() {

--- a/cmd/linuxaid-install/main.go
+++ b/cmd/linuxaid-install/main.go
@@ -11,7 +11,6 @@ import (
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/helper"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/helper/logger"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/prettyfmt"
-	"github.com/spf13/pflag"
 )
 
 var Version string
@@ -81,30 +80,23 @@ func init() {
 	rootCmd.Flags().StringVar(&certNameFlag, constant.CobraFlagCertname, "", "Certificate name (defaults to the machine's FQDN)")
 	rootCmd.Flags().StringVar(&openvoxServerFlag, constant.CobraFlagOpenvoxServer, defaultServer, "Puppet server hostname")
 	rootCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, constant.DefaultOpenvoxEnv, "Openvox environment to install (Linuxaid release version)")
-	// --openvox-environment was the original name and appears in the documented install commands
-	rootCmd.SetGlobalNormalizationFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
-		if name == constant.CobraFlagOpenvoxEnv {
-			name = constant.CobraFlagEnvironment
-		}
-		return pflag.NormalizedName(name)
-	})
 
 	// Bind flags to viper
 	v := config.GetViperInstance()
 	v.BindPFlag(constant.CobraFlagDebug, rootCmd.Flags().Lookup(constant.CobraFlagDebug))
 	v.BindPFlag(constant.CobraFlagCertname, rootCmd.Flags().Lookup(constant.CobraFlagCertname))
 	v.BindPFlag(constant.CobraFlagOpenvoxServer, rootCmd.Flags().Lookup(constant.CobraFlagOpenvoxServer))
-	v.BindPFlag(constant.CobraFlagOpenvoxEnv, rootCmd.Flags().Lookup(constant.CobraFlagEnvironment))
+	v.BindPFlag(constant.ViperKeyInstallEnvironment, rootCmd.Flags().Lookup(constant.CobraFlagEnvironment))
 
 	// Bind environment variables
 	v.BindEnv(constant.CobraFlagDebug)
 	v.BindEnv(constant.CobraFlagCertname)
 	v.BindEnv(constant.CobraFlagOpenvoxServer, "PUPPET_SERVER")
-	v.BindEnv(constant.CobraFlagOpenvoxEnv, "OPENVOX_ENVIRONMENT")
+	v.BindEnv(constant.ViperKeyInstallEnvironment, "OPENVOX_ENVIRONMENT")
 
 	// Set default values
 	v.SetDefault(constant.CobraFlagOpenvoxServer, defaultServer)
-	v.SetDefault(constant.CobraFlagOpenvoxEnv, constant.DefaultOpenvoxEnv)
+	v.SetDefault(constant.ViperKeyInstallEnvironment, constant.DefaultOpenvoxEnv)
 }
 
 func main() {

--- a/cmd/linuxaid-install/main.go
+++ b/cmd/linuxaid-install/main.go
@@ -11,6 +11,7 @@ import (
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/helper"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/helper/logger"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/prettyfmt"
+	"github.com/spf13/pflag"
 )
 
 var Version string
@@ -79,14 +80,21 @@ func init() {
 	rootCmd.Flags().BoolVar(&debugFlag, "debug", false, "Enable debug logs")
 	rootCmd.Flags().StringVar(&certNameFlag, constant.CobraFlagCertname, "", "Certificate name (defaults to the machine's FQDN)")
 	rootCmd.Flags().StringVar(&openvoxServerFlag, constant.CobraFlagOpenvoxServer, defaultServer, "Puppet server hostname")
-	rootCmd.Flags().StringVar(&openvoxEnvFlag, constant.CobraFlagOpenvoxEnv, constant.DefaultOpenvoxEnv, "Openvox environment (Linuxaid release version)")
+	rootCmd.Flags().StringVarP(&openvoxEnvFlag, constant.CobraFlagEnvironment, constant.CobraFlagEnvironmentShorthand, constant.DefaultOpenvoxEnv, "Openvox environment to install (Linuxaid release version)")
+	// --openvox-environment was the original name and appears in the documented install commands
+	rootCmd.SetGlobalNormalizationFunc(func(_ *pflag.FlagSet, name string) pflag.NormalizedName {
+		if name == constant.CobraFlagOpenvoxEnv {
+			name = constant.CobraFlagEnvironment
+		}
+		return pflag.NormalizedName(name)
+	})
 
 	// Bind flags to viper
 	v := config.GetViperInstance()
 	v.BindPFlag(constant.CobraFlagDebug, rootCmd.Flags().Lookup(constant.CobraFlagDebug))
 	v.BindPFlag(constant.CobraFlagCertname, rootCmd.Flags().Lookup(constant.CobraFlagCertname))
 	v.BindPFlag(constant.CobraFlagOpenvoxServer, rootCmd.Flags().Lookup(constant.CobraFlagOpenvoxServer))
-	v.BindPFlag(constant.CobraFlagOpenvoxEnv, rootCmd.Flags().Lookup(constant.CobraFlagOpenvoxEnv))
+	v.BindPFlag(constant.CobraFlagOpenvoxEnv, rootCmd.Flags().Lookup(constant.CobraFlagEnvironment))
 
 	// Bind environment variables
 	v.BindEnv(constant.CobraFlagDebug)

--- a/cmd/linuxaid-install/main_test.go
+++ b/cmd/linuxaid-install/main_test.go
@@ -25,7 +25,7 @@ func TestInstallEnvironment(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Setenv(constant.EnvVarEnvironment, test.envVar)
+			t.Setenv(constant.EnvVarOpenvoxEnvironment, test.envVar)
 			t.Cleanup(func() {
 				openvoxEnvFlag = ""
 			})

--- a/cmd/linuxaid-install/main_test.go
+++ b/cmd/linuxaid-install/main_test.go
@@ -10,16 +10,13 @@ import (
 // testEnvironment is the environment the flag tests below install with.
 const testEnvironment = "v1_8_3"
 
-// The install environment flag was renamed from --openvox-environment to --environment. The old
-// spelling appears in the documented install commands, so it has to keep working.
-func TestEnvironmentFlagAcceptsBothSpellings(t *testing.T) {
+func TestEnvironmentFlag(t *testing.T) {
 	tests := []struct {
 		name string
 		args []string
 	}{
 		{name: "current spelling", args: []string{"--environment", testEnvironment}},
 		{name: "shorthand", args: []string{"-E", testEnvironment}},
-		{name: "deprecated spelling", args: []string{"--openvox-environment", testEnvironment}},
 	}
 
 	for _, test := range tests {
@@ -36,15 +33,15 @@ func TestEnvironmentFlagAcceptsBothSpellings(t *testing.T) {
 				t.Errorf("expected the flag to be %q, got %q", testEnvironment, openvoxEnvFlag)
 			}
 
-			if environment := config.GetOpenvoxEnv(); environment != testEnvironment {
+			if environment := config.GetInstallEnvironment(); environment != testEnvironment {
 				t.Errorf("expected the resolved environment to be %q, got %q", testEnvironment, environment)
 			}
 		})
 	}
 }
 
-// viper runs with AutomaticEnv, so the flag is deliberately kept under the openvox-environment key:
-// a key named "environment" would be satisfied by any stray ENVIRONMENT variable on the host.
+// viper runs with AutomaticEnv, so the flag is deliberately bound to a key that is not named
+// "environment": such a key would be satisfied by any stray ENVIRONMENT variable on the host.
 func TestEnvironmentFlagIgnoresStrayEnvironmentVariable(t *testing.T) {
 	t.Setenv("ENVIRONMENT", "leaked-from-env")
 	t.Cleanup(func() {
@@ -55,7 +52,7 @@ func TestEnvironmentFlagIgnoresStrayEnvironmentVariable(t *testing.T) {
 		t.Fatalf("could not parse flags: %v", err)
 	}
 
-	if environment := config.GetOpenvoxEnv(); environment != testEnvironment {
+	if environment := config.GetInstallEnvironment(); environment != testEnvironment {
 		t.Errorf("expected the resolved environment to be %q, got %q", testEnvironment, environment)
 	}
 }

--- a/cmd/linuxaid-install/main_test.go
+++ b/cmd/linuxaid-install/main_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"testing"
+
+	"gitea.obmondo.com/EnableIT/linuxaid-cli/config"
+	"gitea.obmondo.com/EnableIT/linuxaid-cli/constant"
+)
+
+// The install environment flag was renamed from --openvox-environment to --environment. The old
+// spelling appears in the documented install commands, so it has to keep working.
+func TestEnvironmentFlagAcceptsBothSpellings(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "current spelling", args: []string{"--environment", "v1_8_3"}},
+		{name: "shorthand", args: []string{"-E", "v1_8_3"}},
+		{name: "deprecated spelling", args: []string{"--openvox-environment", "v1_8_3"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Cleanup(func() {
+				openvoxEnvFlag = constant.DefaultOpenvoxEnv
+			})
+
+			if err := rootCmd.ParseFlags(test.args); err != nil {
+				t.Fatalf("could not parse %v: %v", test.args, err)
+			}
+
+			if openvoxEnvFlag != "v1_8_3" {
+				t.Errorf("expected the flag to be v1_8_3, got %q", openvoxEnvFlag)
+			}
+
+			if environment := config.GetOpenvoxEnv(); environment != "v1_8_3" {
+				t.Errorf("expected the resolved environment to be v1_8_3, got %q", environment)
+			}
+		})
+	}
+}
+
+// viper runs with AutomaticEnv, so the flag is deliberately kept under the openvox-environment key:
+// a key named "environment" would be satisfied by any stray ENVIRONMENT variable on the host.
+func TestEnvironmentFlagIgnoresStrayEnvironmentVariable(t *testing.T) {
+	t.Setenv("ENVIRONMENT", "leaked-from-env")
+	t.Cleanup(func() {
+		openvoxEnvFlag = constant.DefaultOpenvoxEnv
+	})
+
+	if err := rootCmd.ParseFlags([]string{"--environment", "v1_8_3"}); err != nil {
+		t.Fatalf("could not parse flags: %v", err)
+	}
+
+	if environment := config.GetOpenvoxEnv(); environment != "v1_8_3" {
+		t.Errorf("expected the resolved environment to be v1_8_3, got %q", environment)
+	}
+}

--- a/cmd/linuxaid-install/main_test.go
+++ b/cmd/linuxaid-install/main_test.go
@@ -3,56 +3,40 @@ package main
 import (
 	"testing"
 
-	"gitea.obmondo.com/EnableIT/linuxaid-cli/config"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/constant"
 )
 
 // testEnvironment is the environment the flag tests below install with.
 const testEnvironment = "v1_8_3"
 
-func TestEnvironmentFlag(t *testing.T) {
+func TestInstallEnvironment(t *testing.T) {
 	tests := []struct {
-		name string
-		args []string
+		name     string
+		args     []string
+		envVar   string
+		expected string
 	}{
-		{name: "current spelling", args: []string{"--environment", testEnvironment}},
-		{name: "shorthand", args: []string{"-E", testEnvironment}},
+		{name: "flag", args: []string{"--environment", testEnvironment}, expected: testEnvironment},
+		{name: "shorthand", args: []string{"-E", testEnvironment}, expected: testEnvironment},
+		{name: "environment variable", envVar: testEnvironment, expected: testEnvironment},
+		{name: "the flag wins over the environment variable", args: []string{"--environment", testEnvironment}, envVar: "from-env", expected: testEnvironment},
+		{name: "neither given", expected: constant.DefaultOpenvoxEnv},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Setenv(constant.EnvVarEnvironment, test.envVar)
 			t.Cleanup(func() {
-				openvoxEnvFlag = constant.DefaultOpenvoxEnv
+				openvoxEnvFlag = ""
 			})
 
 			if err := rootCmd.ParseFlags(test.args); err != nil {
 				t.Fatalf("could not parse %v: %v", test.args, err)
 			}
 
-			if openvoxEnvFlag != testEnvironment {
-				t.Errorf("expected the flag to be %q, got %q", testEnvironment, openvoxEnvFlag)
-			}
-
-			if environment := config.GetInstallEnvironment(); environment != testEnvironment {
-				t.Errorf("expected the resolved environment to be %q, got %q", testEnvironment, environment)
+			if environment := installEnvironment(); environment != test.expected {
+				t.Errorf("expected the environment to be %q, got %q", test.expected, environment)
 			}
 		})
-	}
-}
-
-// viper runs with AutomaticEnv, so the flag is deliberately bound to a key that is not named
-// "environment": such a key would be satisfied by any stray ENVIRONMENT variable on the host.
-func TestEnvironmentFlagIgnoresStrayEnvironmentVariable(t *testing.T) {
-	t.Setenv("ENVIRONMENT", "leaked-from-env")
-	t.Cleanup(func() {
-		openvoxEnvFlag = constant.DefaultOpenvoxEnv
-	})
-
-	if err := rootCmd.ParseFlags([]string{"--environment", testEnvironment}); err != nil {
-		t.Fatalf("could not parse flags: %v", err)
-	}
-
-	if environment := config.GetInstallEnvironment(); environment != testEnvironment {
-		t.Errorf("expected the resolved environment to be %q, got %q", testEnvironment, environment)
 	}
 }

--- a/cmd/linuxaid-install/main_test.go
+++ b/cmd/linuxaid-install/main_test.go
@@ -7,6 +7,9 @@ import (
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/constant"
 )
 
+// testEnvironment is the environment the flag tests below install with.
+const testEnvironment = "v1_8_3"
+
 // The install environment flag was renamed from --openvox-environment to --environment. The old
 // spelling appears in the documented install commands, so it has to keep working.
 func TestEnvironmentFlagAcceptsBothSpellings(t *testing.T) {
@@ -14,9 +17,9 @@ func TestEnvironmentFlagAcceptsBothSpellings(t *testing.T) {
 		name string
 		args []string
 	}{
-		{name: "current spelling", args: []string{"--environment", "v1_8_3"}},
-		{name: "shorthand", args: []string{"-E", "v1_8_3"}},
-		{name: "deprecated spelling", args: []string{"--openvox-environment", "v1_8_3"}},
+		{name: "current spelling", args: []string{"--environment", testEnvironment}},
+		{name: "shorthand", args: []string{"-E", testEnvironment}},
+		{name: "deprecated spelling", args: []string{"--openvox-environment", testEnvironment}},
 	}
 
 	for _, test := range tests {
@@ -29,12 +32,12 @@ func TestEnvironmentFlagAcceptsBothSpellings(t *testing.T) {
 				t.Fatalf("could not parse %v: %v", test.args, err)
 			}
 
-			if openvoxEnvFlag != "v1_8_3" {
-				t.Errorf("expected the flag to be v1_8_3, got %q", openvoxEnvFlag)
+			if openvoxEnvFlag != testEnvironment {
+				t.Errorf("expected the flag to be %q, got %q", testEnvironment, openvoxEnvFlag)
 			}
 
-			if environment := config.GetOpenvoxEnv(); environment != "v1_8_3" {
-				t.Errorf("expected the resolved environment to be v1_8_3, got %q", environment)
+			if environment := config.GetOpenvoxEnv(); environment != testEnvironment {
+				t.Errorf("expected the resolved environment to be %q, got %q", testEnvironment, environment)
 			}
 		})
 	}
@@ -48,11 +51,11 @@ func TestEnvironmentFlagIgnoresStrayEnvironmentVariable(t *testing.T) {
 		openvoxEnvFlag = constant.DefaultOpenvoxEnv
 	})
 
-	if err := rootCmd.ParseFlags([]string{"--environment", "v1_8_3"}); err != nil {
+	if err := rootCmd.ParseFlags([]string{"--environment", testEnvironment}); err != nil {
 		t.Fatalf("could not parse flags: %v", err)
 	}
 
-	if environment := config.GetOpenvoxEnv(); environment != "v1_8_3" {
-		t.Errorf("expected the resolved environment to be v1_8_3, got %q", environment)
+	if environment := config.GetOpenvoxEnv(); environment != testEnvironment {
+		t.Errorf("expected the resolved environment to be %q, got %q", testEnvironment, environment)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -29,6 +29,13 @@ func GetOpenvoxEnv() string {
 	return viperConfig.GetString(constant.CobraFlagOpenvoxEnv)
 }
 
+// GetEnvironment returns the puppet environment requested for a single run through
+// --environment/-E, empty when the flag was not given.
+func GetEnvironment() string {
+	initIfNil()
+	return viperConfig.GetString(constant.CobraFlagEnvironment)
+}
+
 func IsDebug() bool {
 	initIfNil()
 	return viperConfig.GetBool(constant.CobraFlagDebug)

--- a/config/config.go
+++ b/config/config.go
@@ -24,12 +24,6 @@ func GetOpenvoxServer() string {
 	return viperConfig.GetString(constant.CobraFlagOpenvoxServer)
 }
 
-// GetInstallEnvironment returns the environment linuxaid-install bootstraps a node with.
-func GetInstallEnvironment() string {
-	initIfNil()
-	return viperConfig.GetString(constant.ViperKeyInstallEnvironment)
-}
-
 func IsDebug() bool {
 	initIfNil()
 	return viperConfig.GetBool(constant.CobraFlagDebug)

--- a/config/config.go
+++ b/config/config.go
@@ -29,13 +29,6 @@ func GetOpenvoxEnv() string {
 	return viperConfig.GetString(constant.CobraFlagOpenvoxEnv)
 }
 
-// GetEnvironment returns the puppet environment requested for a single run through
-// --environment/-E, empty when the flag was not given.
-func GetEnvironment() string {
-	initIfNil()
-	return viperConfig.GetString(constant.CobraFlagEnvironment)
-}
-
 func IsDebug() bool {
 	initIfNil()
 	return viperConfig.GetBool(constant.CobraFlagDebug)

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,10 @@ func GetOpenvoxServer() string {
 	return viperConfig.GetString(constant.CobraFlagOpenvoxServer)
 }
 
-func GetOpenvoxEnv() string {
+// GetInstallEnvironment returns the environment linuxaid-install bootstraps a node with.
+func GetInstallEnvironment() string {
 	initIfNil()
-	return viperConfig.GetString(constant.CobraFlagOpenvoxEnv)
+	return viperConfig.GetString(constant.ViperKeyInstallEnvironment)
 }
 
 func IsDebug() bool {

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -40,7 +40,11 @@ const (
 	CobraFlagDebug         = "debug"
 	CobraFlagCertname      = "certname"
 	CobraFlagOpenvoxServer = "puppet-server"
-	CobraFlagOpenvoxEnv    = "openvox-environment"
+	// CobraFlagOpenvoxEnv is the previous name of linuxaid-install's --environment flag, kept as a
+	// deprecated alias so documented install commands keep working. It stays the viper key for
+	// that flag as well: viper runs with AutomaticEnv, so a key named "environment" would be
+	// satisfied by any stray ENVIRONMENT variable on the host.
+	CobraFlagOpenvoxEnv = "openvox-environment"
 	// CobraFlagEnvironment mirrors puppet's own --environment/-E flag on run-openvox
 	CobraFlagEnvironment          = "environment"
 	CobraFlagEnvironmentShorthand = "E"

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -37,13 +37,16 @@ const (
 	BarSizeHundred     = 100
 
 	// Cobra Flags
-	CobraFlagDebug               = "debug"
-	CobraFlagCertname            = "certname"
-	CobraFlagOpenvoxServer       = "puppet-server"
-	CobraFlagOpenvoxEnv          = "openvox-environment"
-	CobraFlagNoReboot            = "no-reboot"
-	CobraFlagSkipOpenvox         = "skip-openvox"
-	CobraFlagSecurityExporterURL = "security-exporter-url"
+	CobraFlagDebug         = "debug"
+	CobraFlagCertname      = "certname"
+	CobraFlagOpenvoxServer = "puppet-server"
+	CobraFlagOpenvoxEnv    = "openvox-environment"
+	// CobraFlagEnvironment mirrors puppet's own --environment/-E flag on run-openvox
+	CobraFlagEnvironment          = "environment"
+	CobraFlagEnvironmentShorthand = "E"
+	CobraFlagNoReboot             = "no-reboot"
+	CobraFlagSkipOpenvox          = "skip-openvox"
+	CobraFlagSecurityExporterURL  = "security-exporter-url"
 
 	ObmondoEnv = "OBMONDO_ENV"
 )

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -43,8 +43,10 @@ const (
 	// CobraFlagEnvironment mirrors puppet's own --environment/-E flag
 	CobraFlagEnvironment          = "environment"
 	CobraFlagEnvironmentShorthand = "E"
-	// EnvVarEnvironment is the environment variable form of --environment
-	EnvVarEnvironment            = "ENVIRONMENT"
+	// EnvVarOpenvoxEnvironment is the environment variable form of linuxaid-install's --environment
+	// flag. It is deliberately not called ENVIRONMENT, which CI systems and deploy tooling
+	// commonly set for their own purposes.
+	EnvVarOpenvoxEnvironment     = "OPENVOX_ENVIRONMENT"
 	CobraFlagNoReboot            = "no-reboot"
 	CobraFlagSkipOpenvox         = "skip-openvox"
 	CobraFlagSecurityExporterURL = "security-exporter-url"

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -40,16 +40,14 @@ const (
 	CobraFlagDebug         = "debug"
 	CobraFlagCertname      = "certname"
 	CobraFlagOpenvoxServer = "puppet-server"
-	// ViperKeyInstallEnvironment is the viper key behind linuxaid-install's --environment flag. It
-	// deliberately does not match the flag name: viper runs with AutomaticEnv, so a key named
-	// "environment" would be satisfied by any stray ENVIRONMENT variable on the host.
-	ViperKeyInstallEnvironment = "install-environment"
-	// CobraFlagEnvironment mirrors puppet's own --environment/-E flag on run-openvox
+	// CobraFlagEnvironment mirrors puppet's own --environment/-E flag
 	CobraFlagEnvironment          = "environment"
 	CobraFlagEnvironmentShorthand = "E"
-	CobraFlagNoReboot             = "no-reboot"
-	CobraFlagSkipOpenvox          = "skip-openvox"
-	CobraFlagSecurityExporterURL  = "security-exporter-url"
+	// EnvVarEnvironment is the environment variable form of --environment
+	EnvVarEnvironment            = "ENVIRONMENT"
+	CobraFlagNoReboot            = "no-reboot"
+	CobraFlagSkipOpenvox         = "skip-openvox"
+	CobraFlagSecurityExporterURL = "security-exporter-url"
 
 	ObmondoEnv = "OBMONDO_ENV"
 )

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -40,11 +40,10 @@ const (
 	CobraFlagDebug         = "debug"
 	CobraFlagCertname      = "certname"
 	CobraFlagOpenvoxServer = "puppet-server"
-	// CobraFlagOpenvoxEnv is the previous name of linuxaid-install's --environment flag, kept as a
-	// deprecated alias so documented install commands keep working. It stays the viper key for
-	// that flag as well: viper runs with AutomaticEnv, so a key named "environment" would be
-	// satisfied by any stray ENVIRONMENT variable on the host.
-	CobraFlagOpenvoxEnv = "openvox-environment"
+	// ViperKeyInstallEnvironment is the viper key behind linuxaid-install's --environment flag. It
+	// deliberately does not match the flag name: viper runs with AutomaticEnv, so a key named
+	// "environment" would be satisfied by any stray ENVIRONMENT variable on the host.
+	ViperKeyInstallEnvironment = "install-environment"
 	// CobraFlagEnvironment mirrors puppet's own --environment/-E flag on run-openvox
 	CobraFlagEnvironment          = "environment"
 	CobraFlagEnvironmentShorthand = "E"

--- a/mock/api.go
+++ b/mock/api.go
@@ -10,6 +10,9 @@ import (
 	api "gitea.obmondo.com/EnableIT/linuxaid-cli/pkg/obmondo"
 )
 
+// MockServerEnvironment is the puppet environment the mock API resolves for every certname.
+const MockServerEnvironment = "v1_0_0"
+
 // nolint: revive
 type MockObmondoClient struct{}
 
@@ -30,6 +33,11 @@ func (*MockObmondoClient) ServerPing() error {
 // UpdatePuppetLastRunReport implements api.ObmondoClient.
 func (*MockObmondoClient) UpdatePuppetLastRunReport() error {
 	return nil
+}
+
+// GetServerEnvironment implements api.ObmondoClient.
+func (*MockObmondoClient) GetServerEnvironment(_ string) (string, error) {
+	return MockServerEnvironment, nil
 }
 
 func (*MockObmondoClient) GetCustomerSettings(_ string) (*api.CustomerSettings, error) {

--- a/pkg/obmondo/model.go
+++ b/pkg/obmondo/model.go
@@ -48,3 +48,10 @@ type CustomerSettings struct {
 	CustomerID string            `json:"customer_id"`
 	LinuxAid   *LinuxAidSettings `json:"linuxaid,omitempty"`
 }
+
+// ServerEnvironment is the puppet environment the API resolved for a certname: the pinned
+// override when one exists, otherwise the latest linuxaid tag.
+type ServerEnvironment struct {
+	Certname    string `json:"certname"`
+	Environment string `json:"environment"`
+}

--- a/pkg/obmondo/obmondo.go
+++ b/pkg/obmondo/obmondo.go
@@ -34,6 +34,7 @@ type ObmondoClient interface {
 	NotifyInstallScriptFailure(input *InstallScriptInput) error
 	ServerPing() error
 	UpdatePuppetLastRunReport() error
+	GetServerEnvironment(certname string) (string, error)
 }
 
 type obmondoClient struct {
@@ -393,6 +394,36 @@ func (c *obmondoClient) GetCustomerSettings(customerID string) (*CustomerSetting
 	}
 
 	return &apiResp.Data, nil
+}
+
+// GetServerEnvironment asks the API which puppet environment this node should run with. The
+// endpoint is authenticated by the node's client certificate and always resolves an answer, so an
+// empty environment means the API could not decide and the caller has to fall back.
+func (c *obmondoClient) GetServerEnvironment(certname string) (string, error) {
+	environmentURL := fmt.Sprintf("%s/servers/environment/certname/%s", c.apiURL, certname)
+
+	resp, err := c.apiCallWithTransport(environmentURL, nil, http.MethodGet)
+	defer func() {
+		if resp != nil && resp.Body != nil {
+			if cerr := resp.Body.Close(); cerr != nil {
+				slog.Error("failed to close body", slog.Any("error", cerr))
+			}
+		}
+	}()
+	if err != nil {
+		return "", fmt.Errorf("failed to fetch the puppet environment: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code fetching the puppet environment: %d", resp.StatusCode)
+	}
+
+	var apiResp ObmondoAPIResponse[ServerEnvironment]
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return "", fmt.Errorf("failed to decode the puppet environment: %w", err)
+	}
+
+	return apiResp.Data.Environment, nil
 }
 
 func NewObmondoClient(obmondoAPIURL string, notifyInstallScriptFailure bool) ObmondoClient {

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -27,9 +27,6 @@ type Service struct {
 	apiClient     api.ObmondoClient
 	certName      string
 	openvoxServer string
-	// openvoxEnv is the environment the node is bootstrapped with, used for the install run only:
-	// later runs get their environment from Obmondo through linuxaid-cli.
-	openvoxEnv string
 }
 
 // NewService initializes a new Puppet service instance
@@ -39,7 +36,6 @@ func NewService(apiClient api.ObmondoClient, webtee *webtee.Webtee) *Service {
 		apiClient:     apiClient,
 		certName:      helper.GetCertname(),
 		openvoxServer: config.GetOpenvoxServer(),
-		openvoxEnv:    config.GetOpenvoxEnv(),
 		webtee:        webtee,
 	}
 }

--- a/pkg/puppet/puppet.go
+++ b/pkg/puppet/puppet.go
@@ -27,7 +27,9 @@ type Service struct {
 	apiClient     api.ObmondoClient
 	certName      string
 	openvoxServer string
-	openvoxEnv    string
+	// openvoxEnv is the environment the node is bootstrapped with, used for the install run only:
+	// later runs get their environment from Obmondo through linuxaid-cli.
+	openvoxEnv string
 }
 
 // NewService initializes a new Puppet service instance
@@ -87,9 +89,13 @@ func (*Service) DisableAgent(msg string) error {
 	return nil
 }
 
-// Run agent
-func (s *Service) RunAgent(remoteLog bool, noopMode string) int {
+// RunAgent runs the puppet agent. The environment is passed on the command line rather than read
+// from puppet.conf, which no longer pins one: the caller decides which environment a run uses.
+func (s *Service) RunAgent(remoteLog bool, noopMode, environment string) int {
 	cmd := fmt.Sprintf("puppet agent -t --%s --detailed-exitcodes", noopMode)
+	if environment != "" {
+		cmd += " --environment " + environment
+	}
 	if remoteLog {
 		s.webtee.RemoteLogObmondo([]string{cmd}, s.certName)
 		return 0
@@ -143,6 +149,8 @@ func (s *Service) WaitForAgent(timeoutSeconds int) {
 
 // Configure agent
 func (s *Service) ConfigureAgent() {
+	// no environment here on purpose: pinning one in puppet.conf would compete with the
+	// environment the caller passes to each run, and the two would eventually disagree
 	cfg := `[main]
 server = %s
 certname = %s
@@ -153,13 +161,12 @@ masterport = 443
 report = true
 pluginsync = true
 noop = true
-environment = %s
 `
 	server := s.openvoxServer
 	if parsed, err := url.Parse(server); err == nil && parsed.Hostname() != "" {
 		server = parsed.Hostname()
 	}
-	content := fmt.Sprintf(cfg, server, s.certName, s.openvoxEnv)
+	content := fmt.Sprintf(cfg, server, s.certName)
 	if err := os.WriteFile(constant.PuppetConfig, []byte(content), os.FileMode(os.O_TRUNC|os.O_CREATE)); err != nil {
 		s.webtee.RemoteLogObmondo([]string{fmt.Sprintf("echo failed to configure puppet: %s", err)}, s.certName)
 		os.Exit(1)


### PR DESCRIPTION
Part of the change that moves ownership of the puppet environment from the ENC to the agent.

Today the ENC returns an environment for every node, and an ENC-supplied environment overrides whatever the agent asks for — so `puppet agent -t -E <environment>` is a no-op. This adds the agent side of the fix.

## What changes

- `GetServerEnvironment()` on the Obmondo client. It calls the new certificate-authenticated `GET /servers/environment/certname/{certname}` in obmondo-api-go, which resolves the environment for the node: the override pinned through the UI, or the latest linuxaid release when nothing is pinned.
- `run-openvox --environment <env>` (shorthand `-E`, matching puppet's own flag) for a one-off run against another branch or tag.
- `RunAgent` takes the environment and passes it as `--environment`, so **every** run carries one: `run-openvox`, the `system-update` run, and the install run.
- `ConfigureAgent` no longer writes `environment` into the puppet.conf it lays down at install time.

## Why puppet.conf stops pinning the environment

The installer wrote `environment = <bootstrap release>` into `/etc/puppetlabs/puppet/puppet.conf`, and the puppet-managed template did the same afterwards. With the agent deciding per run, an on-disk pin is a second source of truth that only shows up when the command line is missing one — exactly when it would be most surprising. The install run now passes its bootstrap environment explicitly instead, and `system-update` resolves the environment the same way `run-openvox` does.

## Precedence

1. `--environment`/`-E` — a one-off run. It is never sent to the API, so it applies to this run only and leaves nothing behind.
2. the environment the API resolved for this certname.
3. `constant.DefaultOpenvoxEnv` (`master`) — when the flag is unset and the API is unreachable, answers nothing, or the node is in opensource mode.

The flag is read straight from cobra rather than through viper. `config` calls `viper.AutomaticEnv()`, so a viper-bound flag named `environment` would be satisfied by a plain `ENVIRONMENT` variable — common enough in shells and CI that it would silently pin the environment for every run on that host. There is deliberately no `OPENVOX_ENVIRONMENT` binding either: `linuxaid-install` uses that variable for the release a node is bootstrapped with, and reusing it here would have the same effect.

## Note on the fallback

A node pinned to an older release that cannot reach the API will run `master` instead of failing. That is a deliberate change from today, where the ENC exits 1 and the run aborts.

## Rollout

This must be everywhere **before** the matching linuxaid change lands. An old CLI that sends no `--environment`, combined with an ENC that no longer returns one, leaves the run on puppet's built-in `production`.

Companion PRs: obmondo-api-go (the GET endpoint) and Obmondo/LinuxAid#58 (ENC + puppet.conf).

## Testing

`TestResolveOpenvoxEnvironment` covers all five precedence paths; full suite green. Verified separately that `ENVIRONMENT=…` in the environment no longer influences the resolved value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)