### PR TITLE
fix: updated puppet success exit status codes

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -58,6 +58,4 @@ const (
 	PuppetWaitForCertTimeOut = 600
 )
 
-var (
-	PuppetSuccessExitCodes = []int{0, 2}
-)
+var PuppetSuccessExitCodes = []int{0, 2, 6}


### PR DESCRIPTION
exit code 6 is also considered success as puppet run with success and errors