### PR TITLE
fix(system-update): reboot reliably after a kernel update

### DIFF
--- a/internal/system/kernel.go
+++ b/internal/system/kernel.go
@@ -1,22 +1,38 @@
 package system
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
+	"time"
 
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/internal/disk"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/internal/shell"
 )
 
-const bootDirectory = "/boot"
+const (
+	rebootCommand = "reboot --force"
 
-// CheckKernelAndRebootIfNeeded checks if a new kernel is installed and reboots if necessary.
+	// rebootGraceMinutes is how many minutes reboot waits for the kernel to bring the
+	// machine down before it concludes the reboot request was lost.
+	rebootGraceMinutes = 5
+)
+
+// bootDirectory and rebootGracePeriod are vars, not consts, so tests can point them at a
+// temporary directory and shorten the wait.
+var (
+	bootDirectory     = "/boot"
+	rebootGracePeriod = rebootGraceMinutes * time.Minute
+)
+
+// CheckKernelAndRebootIfNeeded reboots the node when a newer kernel than the running one is
+// installed, unless noReboot is set. It always logs which branch it took: a silent no-op here
+// is what previously hid nodes that never rebooted after an update.
 func CheckKernelAndRebootIfNeeded(runner shell.Runner, noReboot bool) error {
-	// Get installed kernel of the system
-	// If kernel is installed, then only we will try to reboot.
-	// In lxc kernel wont be present
-	installedKernel, err := getInstalledKernel(runner, bootDirectory)
+	// In an LXC container there is no kernel in /boot and nothing to reboot into.
+	installedKernel, err := getInstalledKernel(bootDirectory)
 	if err != nil {
 		slog.Error("error occurred while trying to find kernel", slog.String("error", err.Error()))
 		return err
@@ -26,7 +42,6 @@ func CheckKernelAndRebootIfNeeded(runner shell.Runner, noReboot bool) error {
 		return nil
 	}
 
-	// Get running kernel of the system
 	running := runner.Capture("uname -r")
 	if running.Err != nil {
 		slog.Error("Failed to fetch Running Kernel", slog.Any("error", running.Err))
@@ -34,25 +49,74 @@ func CheckKernelAndRebootIfNeeded(runner shell.Runner, noReboot bool) error {
 	}
 	runningKernel := strings.TrimSpace(running.Output)
 
-	// Check the disk size
+	if installedKernel == runningKernel {
+		slog.Info("running kernel is already the newest installed kernel, no reboot needed",
+			slog.String("kernel", runningKernel))
+		return nil
+	}
+
+	if noReboot {
+		slog.Info("a newer kernel is installed but reboot is disabled, not rebooting",
+			slog.String("installed_kernel", installedKernel),
+			slog.String("running_kernel", runningKernel))
+		return nil
+	}
+
 	if err := disk.CheckDiskSize(); err != nil {
 		slog.Error("unable to check disk size", slog.String("error", err.Error()))
 		return err
 	}
 
-	// Reboot the node, if we have installed a new kernel
-	if installedKernel != runningKernel && !noReboot {
-		slog.Info("looks like newer kernel is installed, so going ahead with reboot now")
-		runner.Run("reboot --force")
-	}
-
-	return nil
+	return reboot(runner, installedKernel, runningKernel)
 }
 
-// getInstalledKernel returns the installed Kernel
-func getInstalledKernel(runner shell.Runner, bootDirectory string) (string, error) {
-	formatedBashCommand := fmt.Sprintf("find %s/vmlinuz-* | sort -V | tail -n 1 | sed 's|.*vmlinuz-||'", bootDirectory)
-	result := runner.Capture(fmt.Sprintf("/bin/bash -c \"%s\"", formatedBashCommand))
+// reboot asks PID 1 to reboot and then blocks until the machine goes down. The request is
+// asynchronous, so this process must not return: obmondo-system-update.service is Type=oneshot,
+// and once its main process exits systemd tears down the unit's cgroup, which can kill the
+// pending reboot before the kernel goes down. If the machine is still up after the grace
+// period the reboot did not take effect, so report it rather than hang the service forever.
+func reboot(runner shell.Runner, installedKernel, runningKernel string) error {
+	slog.Info("a newer kernel is installed, rebooting now",
+		slog.String("installed_kernel", installedKernel),
+		slog.String("running_kernel", runningKernel))
 
-	return strings.TrimSpace(result.Output), result.Err
+	result := runner.Run(rebootCommand)
+	if result.Err != nil {
+		slog.Error("failed to trigger reboot", slog.Any("error", result.Err))
+		return fmt.Errorf("running %q: %w", rebootCommand, result.Err)
+	}
+	if result.ExitCode != 0 {
+		slog.Error("reboot command exited non-zero", slog.Int("exit_code", result.ExitCode))
+		return fmt.Errorf("%q exited with status %d", rebootCommand, result.ExitCode)
+	}
+
+	slog.Info("reboot requested, waiting for the system to shut down")
+	time.Sleep(rebootGracePeriod)
+
+	slog.Error("still running after the reboot request, reboot did not take effect")
+	return errors.New("system did not reboot within the grace period")
+}
+
+// getInstalledKernel returns the newest kernel version found in bootDirectory (the part after
+// "vmlinuz-"), or "" when the directory holds no kernel image. The GRUB rescue image is not a
+// real kernel candidate and is skipped. Ordering uses compareKernelVersions rather than
+// "sort -V"; see that function for why.
+func getInstalledKernel(bootDirectory string) (string, error) {
+	matches, err := filepath.Glob(filepath.Join(bootDirectory, "vmlinuz-*"))
+	if err != nil {
+		return "", err
+	}
+
+	var newest string
+	for _, match := range matches {
+		version := strings.TrimPrefix(filepath.Base(match), "vmlinuz-")
+		if strings.Contains(version, "rescue") {
+			continue
+		}
+		if newest == "" || compareKernelVersions(version, newest) > 0 {
+			newest = version
+		}
+	}
+
+	return newest, nil
 }

--- a/internal/system/kernel_test.go
+++ b/internal/system/kernel_test.go
@@ -1,8 +1,10 @@
 package system
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/internal/shell"
 	"gitea.obmondo.com/EnableIT/linuxaid-cli/internal/shell/shelltest"
@@ -15,7 +17,7 @@ func TestGetInstalledKernel(t *testing.T) {
 	}
 	expectedKernelOutput := "6.11.0-3-generic"
 
-	latestKernel, err := getInstalledKernel(shell.New(), testBootDirectory)
+	latestKernel, err := getInstalledKernel(testBootDirectory)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -23,7 +25,110 @@ func TestGetInstalledKernel(t *testing.T) {
 		t.Errorf("\n expected: %s\n actual: %s", expectedKernelOutput, latestKernel)
 		t.FailNow()
 	}
+}
 
+// TestGetInstalledKernelPicksNewestRHELKernel is the regression test for the bug where
+// "find /boot/vmlinuz-* | sort -V | tail -1" returned the RHEL point release
+// "4.18.0-553.el8_10" as newest and ranked every z-stream update below it, so a node booted
+// on the point release never saw a reason to reboot.
+func TestGetInstalledKernelPicksNewestRHELKernel(t *testing.T) {
+	bootDir := writeBootDir(t,
+		"4.18.0-553.el8_10.x86_64",
+		"4.18.0-553.137.1.el8_10.x86_64",
+		"4.18.0-553.157.1.el8_10.x86_64",
+		"0-rescue-0123456789abcdef0123456789abcdef",
+	)
+
+	got, err := getInstalledKernel(bootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "4.18.0-553.157.1.el8_10.x86_64"; got != want {
+		t.Errorf("getInstalledKernel() = %q, want %q", got, want)
+	}
+}
+
+func TestGetInstalledKernelEmptyBootDir(t *testing.T) {
+	got, err := getInstalledKernel(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Errorf("getInstalledKernel() = %q, want empty string", got)
+	}
+}
+
+func TestCheckKernelAndRebootIfNeeded(t *testing.T) {
+	origBoot, origGrace := bootDirectory, rebootGracePeriod
+	t.Cleanup(func() {
+		bootDirectory = origBoot
+		rebootGracePeriod = origGrace
+	})
+	rebootGracePeriod = time.Millisecond
+
+	rhelBoot := []string{"4.18.0-553.el8_10.x86_64", "4.18.0-553.157.1.el8_10.x86_64"}
+
+	t.Run("reboots when a newer kernel is installed", func(t *testing.T) {
+		bootDirectory = writeBootDir(t, rhelBoot...)
+		runner := &shelltest.Recorder{Results: map[string]shell.Result{
+			"uname -r": {Output: "4.18.0-553.el8_10.x86_64\n"},
+		}}
+
+		// The fake runner never brings the machine down, so reboot reports that the grace
+		// period elapsed. What matters is that the reboot command was issued.
+		if err := CheckKernelAndRebootIfNeeded(runner, false); err == nil {
+			t.Error("expected an error because the fake runner does not reboot the machine")
+		}
+		if !runner.Ran(rebootCommand) {
+			t.Errorf("expected %q to run, got %v", rebootCommand, runner.Commands())
+		}
+	})
+
+	t.Run("does not reboot when the running kernel is already newest", func(t *testing.T) {
+		bootDirectory = writeBootDir(t, rhelBoot...)
+		runner := &shelltest.Recorder{Results: map[string]shell.Result{
+			"uname -r": {Output: "4.18.0-553.157.1.el8_10.x86_64\n"},
+		}}
+
+		if err := CheckKernelAndRebootIfNeeded(runner, false); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.Ran("reboot") {
+			t.Errorf("expected no reboot, got %v", runner.Commands())
+		}
+	})
+
+	t.Run("does not reboot when reboot is disabled", func(t *testing.T) {
+		bootDirectory = writeBootDir(t, rhelBoot...)
+		runner := &shelltest.Recorder{Results: map[string]shell.Result{
+			"uname -r": {Output: "4.18.0-553.el8_10.x86_64\n"},
+		}}
+
+		if err := CheckKernelAndRebootIfNeeded(runner, true); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if runner.Ran("reboot") {
+			t.Errorf("expected no reboot when noReboot is set, got %v", runner.Commands())
+		}
+	})
+}
+
+// writeBootDir creates a temp directory holding an empty vmlinuz-<version> file per version.
+func writeBootDir(t *testing.T, versions ...string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for _, version := range versions {
+		file, err := os.Create(filepath.Join(dir, "vmlinuz-"+version))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := file.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return dir
 }
 
 // TestUpdateSystemRunsDistributionCommands pins which commands each distribution actually runs,

--- a/internal/system/vercmp.go
+++ b/internal/system/vercmp.go
@@ -1,0 +1,115 @@
+package system
+
+import "strings"
+
+// compareKernelVersions orders two kernel version strings (the part after "vmlinuz-", e.g.
+// "4.18.0-553.157.1.el8_10.x86_64" or "6.8.0-134-generic") the way RPM's rpmvercmp does. It
+// returns -1 if a is older than b, 1 if a is newer, and 0 if they are equal.
+//
+// "sort -V" is deliberately not used for this: GNU version sort ranks the RHEL point release
+// "4.18.0-553.el8_10" above every z-stream update such as "4.18.0-553.157.1.el8_10", because at
+// the character after "553." it compares a letter as greater than a digit. rpmvercmp instead
+// treats a numeric segment as always newer than an alphabetic one, which matches the order the
+// package managers actually use.
+func compareKernelVersions(a, b string) int {
+	if a == b {
+		return 0
+	}
+
+	i, j := 0, 0
+	for i < len(a) || j < len(b) {
+		i = skipSeparators(a, i)
+		j = skipSeparators(b, j)
+
+		// A leading '~' sorts before everything else, including the end of the string.
+		for (i < len(a) && a[i] == '~') || (j < len(b) && b[j] == '~') {
+			if i >= len(a) || a[i] != '~' {
+				return 1
+			}
+			if j >= len(b) || b[j] != '~' {
+				return -1
+			}
+			i++
+			j++
+		}
+
+		if i >= len(a) || j >= len(b) {
+			break
+		}
+
+		numeric := isDigit(a[i])
+		want := isAlpha
+		if numeric {
+			want = isDigit
+		}
+
+		var segA, segB string
+		segA, i = grabSegment(a, i, want)
+		segB, j = grabSegment(b, j, want)
+
+		// The other string has no segment of this type here. A numeric segment is newer
+		// than a missing one; an alphabetic segment is older than a numeric one.
+		if segB == "" {
+			if numeric {
+				return 1
+			}
+			return -1
+		}
+
+		if diff := compareSegments(segA, segB, numeric); diff != 0 {
+			return diff
+		}
+	}
+
+	switch {
+	case i >= len(a) && j >= len(b):
+		return 0
+	case i >= len(a):
+		return -1
+	default:
+		return 1
+	}
+}
+
+func compareSegments(segA, segB string, numeric bool) int {
+	if numeric {
+		segA = strings.TrimLeft(segA, "0")
+		segB = strings.TrimLeft(segB, "0")
+		if len(segA) != len(segB) {
+			if len(segA) > len(segB) {
+				return 1
+			}
+			return -1
+		}
+	}
+
+	switch {
+	case segA == segB:
+		return 0
+	case segA > segB:
+		return 1
+	default:
+		return -1
+	}
+}
+
+func skipSeparators(s string, i int) int {
+	for i < len(s) && !isDigit(s[i]) && !isAlpha(s[i]) && s[i] != '~' {
+		i++
+	}
+	return i
+}
+
+func grabSegment(s string, start int, want func(byte) bool) (segment string, next int) {
+	end := start
+	for end < len(s) && want(s[end]) {
+		end++
+	}
+	return s[start:end], end
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
+
+func isAlpha(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+}

--- a/internal/system/vercmp_test.go
+++ b/internal/system/vercmp_test.go
@@ -1,0 +1,72 @@
+package system
+
+import "testing"
+
+func TestCompareKernelVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b string
+		want int
+	}{
+		{
+			name: "rhel z-stream is newer than the point release",
+			a:    "4.18.0-553.157.1.el8_10.x86_64",
+			b:    "4.18.0-553.el8_10.x86_64",
+			want: 1,
+		},
+		{
+			name: "rhel point release is older than a z-stream",
+			a:    "4.18.0-553.el8_10.x86_64",
+			b:    "4.18.0-553.157.1.el8_10.x86_64",
+			want: -1,
+		},
+		{
+			name: "higher rhel z-stream wins",
+			a:    "4.18.0-553.157.1.el8_10.x86_64",
+			b:    "4.18.0-553.137.1.el8_10.x86_64",
+			want: 1,
+		},
+		{
+			name: "higher ubuntu abi number wins",
+			a:    "6.8.0-134-generic",
+			b:    "6.8.0-111-generic",
+			want: 1,
+		},
+		{
+			name: "higher ubuntu upstream version wins even with a lower abi number",
+			a:    "6.11.0-3-generic",
+			b:    "6.0.0-11-generic",
+			want: 1,
+		},
+		{
+			name: "equal versions",
+			a:    "6.8.0-134-generic",
+			b:    "6.8.0-134-generic",
+			want: 0,
+		},
+		{
+			name: "an extra trailing segment is newer",
+			a:    "1.2.3",
+			b:    "1.2",
+			want: 1,
+		},
+		{
+			name: "tilde sorts before the release",
+			a:    "6.8.0~rc4-generic",
+			b:    "6.8.0-generic",
+			want: -1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := compareKernelVersions(test.a, test.b); got != test.want {
+				t.Errorf("compareKernelVersions(%q, %q) = %d, want %d", test.a, test.b, got, test.want)
+			}
+			// The comparison must be a total order: swapping the arguments negates the result.
+			if got := compareKernelVersions(test.b, test.a); got != -test.want {
+				t.Errorf("compareKernelVersions(%q, %q) = %d, want %d", test.b, test.a, got, -test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Two bugs kept nodes on an old kernel after system-update installed a new one.

1. getInstalledKernel piped `find /boot/vmlinuz-* | sort -V | tail -1` to pick the newest kernel. GNU version sort ranks the RHEL point release `4.18.0-553.el8_10` above every z-stream update (`4.18.0-553.157.1.el8_10`, ...) because after `553.` it compares a letter as greater than a digit. A node booted on the point release therefore compared equal to "newest" and never rebooted. Replace the shell pipeline with a filepath.Glob plus an rpmvercmp-style comparison (compareKernelVersions) that treats a numeric segment as newer than an alphabetic one, matching the package managers.

2. The reboot was fire-and-forget. linuxaid-cli issued `reboot --force` and returned immediately; obmondo-system-update.service is Type=oneshot, so systemd marked the unit finished and tore down its cgroup, killing the pending reboot before PID 1 acted (seen in the journal as the reboot log line and "Deactivated successfully" in the same second, box still up). Now the reboot request's error/exit code is checked and the call blocks until the machine goes down; if the grace period elapses it reports the failure instead of returning silently.

Also log every branch of CheckKernelAndRebootIfNeeded: a silent no-op was what made the first bug invisible in the journal.